### PR TITLE
feat: `-clusterip-as-endpoint` flag

### DIFF
--- a/control-plane/subcommand/sync-catalog/command.go
+++ b/control-plane/subcommand/sync-catalog/command.go
@@ -54,6 +54,7 @@ type Command struct {
 	flagAddK8SNamespaceSuffix bool
 	flagLogLevel              string
 	flagLogJSON               bool
+	flagClusterIPAsEndpoint   bool
 
 	// Flags to support namespaces
 	flagEnableNamespaces           bool     // Use namespacing on all components
@@ -147,6 +148,8 @@ func (c *Command) init() {
 	c.flags.StringVar(&c.flagCrossNamespaceACLPolicy, "consul-cross-namespace-acl-policy", "",
 		"[Enterprise Only] Name of the ACL policy to attach to all created Consul namespaces to allow service "+
 			"discovery across Consul namespaces. Only necessary if ACLs are enabled.")
+	c.flags.BoolVar(&c.flagClusterIPAsEndpoint, "clusterip-as-endpoint", true,
+		"If true, use the service ClusterIP as the endpoint. Not the pod IP addresses.")
 
 	c.consul = &flags.ConsulFlags{}
 	c.k8s = &flags.K8SFlags{}
@@ -291,6 +294,7 @@ func (c *Command) Run(args []string) int {
 				EnableK8SNSMirroring:       c.flagEnableK8SNSMirroring,
 				K8SNSMirroringPrefix:       c.flagK8SNSMirroringPrefix,
 				ConsulNodeName:             c.flagConsulNodeName,
+				ClusterIPAsEndpoint:        c.flagClusterIPAsEndpoint,
 			},
 		}
 


### PR DESCRIPTION
Adds the ability to use the Kubernetes service cluster-ip as the nodes service IP in Consul when syncing. Reduces drift issues caused by the ~30 second sync intervals.

Changes proposed in this PR:
- Introduces the `-clusterip-as-endpoint` flag.

An example of a Kubernetes service:
```
# kubectl get svc
NAME         TYPE           CLUSTER-IP     EXTERNAL-IP             PORT(S)   AGE
nginx        ClusterIP      10.96.146.74   <none>                  80/TCP    12s
```

The entry in Consul after the sync occurs:
<img width="1097" alt="Screen Shot 2022-11-30 at 12 10 01 pm" src="https://user-images.githubusercontent.com/8031921/204898305-13939c78-c80c-4bad-8899-8c2bbc816d78.png">

How I've tested this PR:

Added test `TestServiceResource_clusterIPAsEndpoint` which sets `ClusterIPAsEndpoint` to `true`.

How I expect reviewers to test this PR:

You can run the unit test mentioned above. Please advise if more tests are needed.

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)

  

